### PR TITLE
Made template fetching use generated URLs

### DIFF
--- a/lib/countdown-timer/main.js
+++ b/lib/countdown-timer/main.js
@@ -15,7 +15,7 @@ export class CountdownTimer extends HTMLElement {
   async connectedCallback () {
     this._currentTimeoutReference = null
     this._durationMs = CountdownTimer.DEFAULT_DURATION_MS
-    const template = await getTemplate('./lib/countdown-timer/index.html')
+    const template = await getTemplate(new URL('./index.html', import.meta.url))
 
     this._timeDisplayElement = template.element.getElementById('time-display')
 

--- a/lib/editable-list/main.js
+++ b/lib/editable-list/main.js
@@ -4,7 +4,7 @@ import {getTemplate} from '../jt-component/main.js'
 
 export class EditableList extends HTMLElement {
   async connectedCallback () {
-    this._template = await getTemplate('./lib/editable-list/index.html')
+    this._template = await getTemplate(new URL('./index.html', import.meta.url))
 
     const rootElement = this._template.elements.get('form-and-list')
     this._formElement = rootElement.querySelector('form')

--- a/lib/jt-component/main.js
+++ b/lib/jt-component/main.js
@@ -1,5 +1,8 @@
 /* global fetch, DOMParser */
 
+/**
+ * @param {(URL|string)} templateUrl The URL to the template HTML document.
+ */
 export async function getTemplate (templateUrl) {
   // TODO: maybe cache or memorise this.
   const response = await fetch(templateUrl)


### PR DESCRIPTION
I used the new [`import.meta` module property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta) to get the current module script URL and build an absolute URL to the template file.

This isn't the perfect solution I was looking for (because I still need to use `new URL('./index.html', import.meta.url)` instead of only `'./index.html'`), but it fixes the actual problem of being unable to move the file without breaking it's template importing.

Closes #2 