### PR TITLE
Customise Editable List Via Attributes

### DIFF
--- a/lib/editable-list/index.html
+++ b/lib/editable-list/index.html
@@ -7,7 +7,7 @@
 <body>
   <template id="form-and-list">
     <form>
-      <input type="text" />
+      <input type="text" required />
       <button type="submit">Add</button>
     </form>
 

--- a/lib/editable-list/main.js
+++ b/lib/editable-list/main.js
@@ -8,28 +8,59 @@ import {getTemplate} from '../jt-component/main.js'
  */
 export class EditableList extends HTMLElement {
   /**
-   * Lifecycle callback. Gets called when the component is added to the
-   * document.
+   * Specifies the observed attributes so that `attributeChangedCallback` will
+   * work
+   * @return {string[]}
    */
-  async connectedCallback () {
-    this._template = await getTemplate(new URL('./index.html', import.meta.url))
+  static get observedAttributes () {
+    return ['add-item-text', 'remove-item-text']
+  }
 
-    const rootElement = this._template.elements.get('form-and-list')
-    this._formElement = rootElement.querySelector('form')
-    this._listElement = rootElement.querySelector('ul')
+  /**
+   * This constructor sets up the contents of this component and initialises all
+   * variables.
+   */
+  constructor () {
+    super()
 
-    this._formElement.addEventListener('submit', (event) => {
-      event.preventDefault()
+    // By default we use the "times" symbol (a.k.a. multiplication sign) as the
+    // button text for removing items from this list. This can be customised
+    // by setting the "remove-item-text" attribute.
+    this._removeItemText = '\u00D7'
 
-      const inputElement = this._formElement.querySelector('input')
-      this.addListItem(inputElement.value)
+    const templateUrl = new URL('./index.html', import.meta.url)
+    // This promise is used to wait for the setup to finish.
+    this._setupPromise = this._setupTemplate(templateUrl)
+  }
 
-      this._formElement.reset()
-      inputElement.focus()
-    })
+  /**
+   * Lifecycle callback. Gets called whenever the component's HTML attributes
+   * are changed.
+   * @param {string} name The name of the attribute that has changed
+   * @param {string} oldValue The previous value of the attribute
+   * @param {string} newValue The new value of the attribute after the change
+   */
+  async attributeChangedCallback (name, oldValue, newValue) {
+    // We need to wait for this component to finish setup, because we may need
+    // to access elements of this component below.
+    await this._setupPromise
 
-    const shadowRoot = this.attachShadow({mode: 'open'})
-    shadowRoot.appendChild(rootElement)
+    switch (name) {
+      case 'add-item-text':
+        this._formElement.querySelector('button[type="submit"]')
+          .textContent = newValue
+        break
+      case 'remove-item-text':
+        // We set `_removeItemText` so that all new list items will use this
+        this._removeItemText = newValue
+
+        // We update all existing items in the list so that they reflect this
+        // change.
+        for (const button of this._listElement.querySelectorAll('button')) {
+          button.textContent = newValue
+        }
+        break
+    }
   }
 
   /**
@@ -48,6 +79,35 @@ export class EditableList extends HTMLElement {
   }
 
   /**
+   * Gets the template for the current component and does any necessary setup.
+   * This includes creating and attaching the shadow root.
+   * @param {(Url|string)} templateUrl
+   * @return {ShadowRoot}
+   */
+  async _setupTemplate (templateUrl) {
+    this._template = await getTemplate(templateUrl)
+
+    const rootElement = this._template.elements.get('form-and-list')
+    this._formElement = rootElement.querySelector('form')
+    this._listElement = rootElement.querySelector('ul')
+
+    this._formElement.addEventListener('submit', (event) => {
+      event.preventDefault()
+
+      const inputElement = this._formElement.querySelector('input')
+      this.addListItem(inputElement.value)
+
+      this._formElement.reset()
+      inputElement.focus()
+    })
+
+    const shadowRoot = this.attachShadow({mode: 'open'})
+    shadowRoot.appendChild(rootElement)
+
+    return shadowRoot
+  }
+
+  /**
    * Creates a new list item element
    *
    * @private
@@ -55,7 +115,10 @@ export class EditableList extends HTMLElement {
    * list.
    */
   _createListItemElement () {
-    return this._template.elements.get('list-item').cloneNode(true)
+    const listItem = this._template.elements.get('list-item').cloneNode(true)
       .firstElementChild
+    listItem.querySelector('button').textContent = this._removeItemText
+
+    return listItem
   }
 }


### PR DESCRIPTION
# Overview
This PR adds the ability to customise the editable list buttons' text via attributes.

Closes #18 

# Changes
- Made the input text for the editable list required. In this way the user cannot insert empty items into the list.
- You can now set the text of the add item button via the "add-item-text" attribute.
- You can now set the text of all remove item buttons via the "remove-item-text" attribute.
- Changed the component structure in the same fashion than I did with the countdown timer.