### PR TITLE
Added support for multiple stylesheets

### DIFF
--- a/lib/jt-component/main.js
+++ b/lib/jt-component/main.js
@@ -30,9 +30,13 @@ export async function getTemplate (templateUrl) {
   const templateDocument = (new DOMParser())
     .parseFromString(htmlText, 'text/html')
 
+  /**
+   * Contains all the templates present in the template document.
+   * @type {TemplateList}
+   */
   const templateElements = new TemplateList()
   /**
-   * Contains the first element in the templateElements map. If not templates
+   * Contains the first element in the templateElements map. If no templates
    * were found then this is undefined instead.
    * This is a convenient shortcut when your template document only contains
    * one tempalte.
@@ -41,6 +45,9 @@ export async function getTemplate (templateUrl) {
   let firstTemplateElement
   Array.from(templateDocument.querySelectorAll('template'))
     .forEach((template, index) => {
+      // We loop through all templates in the template document, clone their
+      // contents, and assign them to their respecitve variables.
+
       const element = template.content.cloneNode(true)
       templateElements.set(index, element)
       firstTemplateElement = firstTemplateElement || element
@@ -51,20 +58,38 @@ export async function getTemplate (templateUrl) {
     })
 
   /**
-   * Contains a copy of the style sheet from the template document. If no style
-   * sheet was found then this is undefined instead.
+   * Contains all the stylesheets present in the tempalte document. Each
+   * stylesheet is mapped to its index in the DOM.
+   * @type {TemplateList}
+   */
+  const templateStylesheets = new TemplateList()
+  /**
+   * Contains the first stylesheet in the templateStylesheets map. If no
+   * stylesheets were found then this is undefined instead.
+   * This is a convenient shortcut when your template document only contains
+   * one stylesheet.
    * @type {(HTMLElement|undefined)}
    */
-  const templateStylesheet = (() => {
-    const sheet = templateDocument.querySelector('link[rel="stylesheet"]')
-    if (sheet) { return sheet.cloneNode(true) }
-  })()
+  let firstTemplateStylesheet
+  Array.from(templateDocument.querySelectorAll('link[rel="stylesheet"]'))
+    .forEach((element, index) => {
+      // We loop through all stylesheets in the template document, clone them,
+      // and assign them to their respecitve variables.
+
+      const stylesheet = element.cloneNode(true)
+      templateStylesheets.set(index, stylesheet)
+      firstTemplateStylesheet = firstTemplateStylesheet || stylesheet
+
+      // The DOM Parser doesn't support ID attributes on <link> tags, so we
+      // can't support ID mapping for stylesheets.
+    })
 
   return {
     document: templateDocument,
     elements: templateElements,
     element: firstTemplateElement,
-    stylesheet: templateStylesheet
+    stylesheets: templateStylesheets,
+    stylesheet: firstTemplateStylesheet
   }
 }
 


### PR DESCRIPTION
Closes #16 
- Multiple stylesheets are handled similarly to multiple templates with the exception that ID attributes on the link element are not supported.
- The first stylesheet will be available under the "stylesheet" property of the returned object; similar to how templates work