### PR TITLE
Saving of Distractions to DB

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -172,4 +172,22 @@ export class App {
       })
     })
   }
+
+  /**
+   * Removes the distraction with the given key ID from the DB
+   * @param {number} keyId The ID of the distraction to remove from the DB.
+   * @returns {Promise<undefined>} Resolves once the operation is done.
+   */
+  async deleteDistraction (keyId) {
+    await this.dbPromise
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction('editable-lists', 'readwrite')
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error)
+
+      tx.objectStore('editable-lists').delete(keyId)
+    })
+  }
 }

--- a/app/app.js
+++ b/app/app.js
@@ -37,8 +37,10 @@ export class App {
       request.onerror = () => reject(request.error)
 
       // Upgrade the DB if necessary
-      request.onupgradeneeded = event => dbUpgrade(request.result,
-        event.oldVersion)
+      // noinspection JSUnresolvedVariable
+      request.onupgradeneeded = event => dbUpgrade(event.target.result,
+        event.oldVersion,
+        event.target.transaction)
     }).then(db => { this.db = db })
 
     // Initialise the countdown timer

--- a/app/app.js
+++ b/app/app.js
@@ -107,12 +107,12 @@ export class App {
    * @private
    */
   async _initDistractionList (distractionsElement) {
-    this.distractions = distractionsElement
+    this.distractionsElement = distractionsElement
 
     // Setup the distraction list event listeners
     // When a new list item has been added and it doesn't have an ID yet then
     // add it to the DB.
-    this.distractions.addEventListener('liadded', async (event) => {
+    this.distractionsElement.addEventListener('liadded', async (event) => {
       const liElement = event.detail.liElement
       if (liElement.keyId == null) {
         liElement.keyId = await this.saveDistraction(liElement.text)
@@ -120,7 +120,7 @@ export class App {
     })
     // When a list item has been removed from the view then also remove it from
     // the DB.
-    this.distractions.addEventListener('liremoved',
+    this.distractionsElement.addEventListener('liremoved',
       event => this.deleteDistraction(event.detail.keyId))
 
     // Wait for the DB to be done setting up
@@ -141,7 +141,7 @@ export class App {
       // can be stored in the same table.
       // Here we need to open a cursor and iterate only over the list items
       // that belong to the distraction list.
-      const request = index.openCursor(IDBKeyRange.only(this.distractions.id))
+      const request = index.openCursor(IDBKeyRange.only(this.distractionsElement.id))
 
       request.onerror = () => reject(request.error)
 
@@ -164,7 +164,7 @@ export class App {
     // Add all the distractions that were saved in the DB to the distractions
     // list.
     for (const distraction of distractions) {
-      this.distractions.addListItem(distraction.text, distraction.keyId)
+      this.distractionsElement.addListItem(distraction.text, distraction.keyId)
     }
   }
 
@@ -237,7 +237,7 @@ export class App {
       tx.onabort = () => reject(tx.error)
 
       const request = tx.objectStore('editable-lists').add({
-        elementId: this.distractions.id,
+        elementId: this.distractionsElement.id,
         text
       })
 

--- a/app/app.js
+++ b/app/app.js
@@ -56,19 +56,19 @@ export class App {
    * @private
    */
   async _initCountdownTimer (countdownElement) {
-    this.countdown = countdownElement
+    this.countdownElement = countdownElement
 
     // Setup the countdown event listeners
     // When the countdown starts then save the start timestamp to the DB.
-    this.countdown.addEventListener('countdownstart',
+    this.countdownElement.addEventListener('countdownstart',
       event => this.saveCountdownTimestamp(event.detail.startTimestamp))
     // When the countdown was stopped by the user then remove the timestamp
     // from the DB
-    this.countdown.addEventListener('countdownstop',
+    this.countdownElement.addEventListener('countdownstop',
       () => this.deleteCountdownTimestamp())
     // When the countdown has completed successfully then show the notification
     // and then remove it from the DB.
-    this.countdown.addEventListener('countdowncomplete', async () => {
+    this.countdownElement.addEventListener('countdowncomplete', async () => {
       await this.deleteCountdownTimestamp()
       await this.showNotification()
     })
@@ -85,7 +85,7 @@ export class App {
       tx.onabort = () => reject(tx.error)
 
       const request = tx.objectStore('countdown-timers')
-        .get(this.countdown.id)
+        .get(this.countdownElement.id)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -93,7 +93,7 @@ export class App {
     if (value) {
       // If an object was associated with the current view's countdown timer
       // then resume the countdown from the timestamp stored in the object.
-      this.countdown.resumeCountdown(value.startTimestamp)
+      this.countdownElement.resumeCountdown(value.startTimestamp)
     }
   }
 
@@ -183,7 +183,7 @@ export class App {
       tx.onabort = () => reject(tx.error)
 
       tx.objectStore('countdown-timers').put({
-        id: this.countdown.id,
+        id: this.countdownElement.id,
         startTimestamp: startTimestamp
       })
     })
@@ -202,7 +202,7 @@ export class App {
       tx.onerror = () => reject(tx.error)
       tx.onabort = () => reject(tx.error)
 
-      tx.objectStore('countdown-timers').delete(this.countdown.id)
+      tx.objectStore('countdown-timers').delete(this.countdownElement.id)
     })
   }
 

--- a/app/app.js
+++ b/app/app.js
@@ -115,14 +115,14 @@ export class App {
     // add it to the DB.
     this.distractionsElement.addEventListener('liadded', async (event) => {
       const liElement = event.detail.liElement
-      if (liElement.keyId == null) {
-        liElement.keyId = await this.saveDistraction(liElement.text)
+      if (liElement.dbId == null) {
+        liElement.dbId = await this.saveDistraction(liElement.text)
       }
     })
     // When a list item has been removed from the view then also remove it from
     // the DB.
     this.distractionsElement.addEventListener('liremoved',
-      event => this.deleteDistraction(event.detail.keyId))
+      event => this.deleteDistraction(event.detail.dbId))
 
     // Wait for the DB to be done setting up
     await this.dbPromise
@@ -252,10 +252,10 @@ export class App {
 
   /**
    * Removes the distraction with the given key ID from the DB
-   * @param {number} keyId The ID of the distraction to remove from the DB.
+   * @param {number} dbId The ID of the distraction to remove from the DB.
    * @returns {Promise<undefined>} Resolves once the operation is done.
    */
-  async deleteDistraction (keyId) {
+  async deleteDistraction (dbId) {
     await this.dbPromise
 
     return new Promise((resolve, reject) => {
@@ -264,7 +264,7 @@ export class App {
       tx.onerror = () => reject(tx.error)
       tx.onabort = () => reject(tx.error)
 
-      tx.objectStore(DATABASE.LIST_ITEMS_STORE).delete(keyId)
+      tx.objectStore(DATABASE.LIST_ITEMS_STORE).delete(dbId)
     })
   }
 }

--- a/app/app.js
+++ b/app/app.js
@@ -3,7 +3,7 @@
 import { dbUpgrade } from './db-upgrade.js'
 
 export class App {
-  constructor (countdownElement) {
+  constructor (countdownElement, distractionsElement) {
     // Setup the notification sound for when the Pomodoro is done
     this.notificationSound = new Audio()
     this.notificationSound.src = 'assets/audio/pomodoro-over.mp3'
@@ -16,7 +16,36 @@ export class App {
       this.notificationPermission = Promise.resolve(Notification.permission)
     }
 
-    // Setup all event listeners
+    // Setup the Indexed DB
+    this.dbPromise = new Promise((resolve, reject) => {
+      // Open the DB
+      const request = window.indexedDB.open('mini-pomodoro', 2)
+
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+
+      // Upgrade the DB if necessary
+      request.onupgradeneeded = event => dbUpgrade(request.result,
+        event.oldVersion)
+    }).then(db => { this.db = db })
+
+    // Initialise the countdown timer
+    this._initCountdownTimer(countdownElement)
+
+    // Initialise the distraction list
+    this._initDistractionList(distractionsElement)
+  }
+
+  /**
+   * Initialise the countdown timer. This sets up all event handlers and
+   * retrieves the timer's start timestamp from the DB (if any is available)
+   * @param {HTMLElement} countdownElement The countdown timer element to
+   * initialise
+   * @returns {Promise<void>} Resolves once the timer has been initialised.
+   * @private
+   */
+  async _initCountdownTimer (countdownElement) {
+    // Setup the countdown event listeners
     this.countdown = countdownElement
     this.countdown.addEventListener('countdownstart',
       event => this.saveCountdownTimestamp(event.detail.startTimestamp))
@@ -27,39 +56,42 @@ export class App {
       await this.showNotification()
     })
 
-    // Setup the Indexed DB
-    this.dbPromise = new Promise((resolve, reject) => {
-      // Open the DB and upgrade it if necessary
+    await this.dbPromise
 
-      const request = window.indexedDB.open('mini-pomodoro', 1)
+    // Get the countdown timer's value from the DB. If a value is stored then
+    // the countdown timer will be initialised with that value's start
+    // timestamp.
+    const value = await new Promise((resolve, reject) => {
+      const tx = this.db.transaction('countdown-timers', 'readonly')
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error)
 
+      const request = tx.objectStore('countdown-timers')
+        .get(this.countdown.id)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
-      request.onupgradeneeded = event => dbUpgrade(request.result,
-        event.oldVersion)
     })
-      .then(db => { this.db = db })
-      .then(() => {
-        // Get the object associated with the current view's countdown timer.
 
-        return new Promise((resolve, reject) => {
-          const tx = this.db.transaction('countdown-timers', 'readonly')
-          tx.onerror = () => reject(tx.error)
-          tx.onabort = () => reject(tx.error)
+    if (value) {
+      // If an object was associated with the current view's countdown timer
+      // then resume the countdown from the timestamp stored in the object.
+      this.countdown.resumeCountdown(value.startTimestamp)
+    }
+  }
 
-          const request = tx.objectStore('countdown-timers')
-            .get(this.countdown.id)
-          request.onsuccess = () => resolve(request.result)
-          request.onerror = () => reject(request.error)
-        })
-      })
-      .then((value) => {
-        if (value) {
-          // If an object was associated with the current view's countdown timer
-          // then resume the countdown from the timestamp stored in the object.
-          this.countdown.resumeCountdown(value.startTimestamp)
-        }
-      })
+  async _initDistractionList (distractionsElement) {
+    this.distractions = distractionsElement
+
+    // Setup the distraction list event listeners
+    this.distractions.addEventListener('liadded', async (event) => {
+      const liElement = event.detail.liElement
+      liElement.keyId = await this.saveDistraction(liElement.text)
+    })
+    this.distractions.addEventListener('liremoved',
+      event => this.deleteDistraction(event.detail.keyId))
+
+    await this.dbPromise
+    // TODO: implement
   }
 
   /**
@@ -97,7 +129,6 @@ export class App {
       tx.onabort = () => reject(tx.error)
 
       tx.objectStore('countdown-timers').delete(this.countdown.id)
-      return tx.complete
     })
   }
 
@@ -114,5 +145,31 @@ export class App {
     }
 
     await this.notificationSound.play()
+  }
+
+  /**
+   * Saves a distraction to the database and resolves into the ID of the row
+   * once the transaction is complete.
+   * @param {string} text The distraction
+   * @returns {Promise<number>}
+   */
+  async saveDistraction (text) {
+    await this.dbPromise
+
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction('editable-lists', 'readwrite')
+      tx.oncomplete = () => resolve(successPromise)
+      tx.onerror = () => reject(tx.error)
+      tx.onabort = () => reject(tx.error)
+
+      const request = tx.objectStore('editable-lists').add({
+        elementId: this.distractions.id,
+        text
+      })
+
+      const successPromise = new Promise(resolve => {
+        request.onsuccess = event => resolve(event.target.result)
+      })
+    })
   }
 }

--- a/app/constants.js
+++ b/app/constants.js
@@ -1,0 +1,48 @@
+/**
+ * Contains constants related to the app's database.
+ * @type {Object}
+ */
+export const DATABASE = {
+  /**
+   * The name of the database in which this app resides.
+   * @type {string}
+   */
+  NAME: 'miniPomodoro',
+  /**
+   * The table in which all countdown timers are stored.
+   * @type {string}
+   */
+  COUNTDOWNS_STORE: 'countdownTimers',
+  /**
+   * The key path for individual countdown timers. This is used to uniquely
+   * identify each countdown timer.
+   * @type {string}
+   */
+  COUNTDOWN_ID: 'id',
+  /**
+   * The table in which all list items get stored. This is currently used by
+   * the "distractions" list.
+   * @type {string}
+   */
+  LIST_ITEMS_STORE: 'listItems',
+  /**
+   * The key path for individual list items. This is a unique, auto-incrementing
+   * key that uniquely identifies each list item.
+   * @type {string}
+   */
+  LIST_ITEM_ID: 'id',
+  /**
+   * The key path for lists. This is used to create an index which groups list
+   * items by the lists in which they are found. This allows us to retrieve the
+   * contents of entire lists.
+   * @type {string}
+   */
+  LIST_ID: 'listId',
+  /**
+   * The name of the index that's applied to the list items table. This is
+   * primarily used to find all list items that belong to a list with the given
+   * ID.
+   * @type {string}
+   */
+  LIST_INDEX: 'listIdIndex'
+}

--- a/app/db-upgrade.js
+++ b/app/db-upgrade.js
@@ -1,3 +1,5 @@
+import { DATABASE } from './constants.js'
+
 /**
  * Upgrade code for the app's indexed database. This will upgrade the given DB
  * object to the latest version based on its current version.
@@ -7,14 +9,14 @@
 export function dbUpgrade (db, oldVersion) {
   switch (oldVersion) {
     case 0:
-      db.createObjectStore('countdown-timers', { keyPath: 'id' })
+      db.createObjectStore(DATABASE.COUNTDOWNS_STORE, {
+        keyPath: DATABASE.COUNTDOWN_ID
+      })
     // Fallthrough
     case 1:
-      const editableListObjectStore = db.createObjectStore('editable-lists', {
-        keyPath: 'keyId',
+      db.createObjectStore(DATABASE.LIST_ITEMS_STORE, {
+        keyPath: DATABASE.LIST_ITEM_ID,
         autoIncrement: true
-      })
-
-      editableListObjectStore.createIndex('elementIdIndex', 'elementId')
+      }).createIndex(DATABASE.LIST_INDEX, DATABASE.LIST_ID)
   }
 }

--- a/app/db-upgrade.js
+++ b/app/db-upgrade.js
@@ -1,22 +1,31 @@
-import { DATABASE } from './constants.js'
-
 /**
  * Upgrade code for the app's indexed database. This will upgrade the given DB
  * object to the latest version based on its current version.
  * @param {IDBDatabase} db The Indexed DB to upgrade.
  * @param {number} oldVersion The version of the Indexed DB before upgrading.
+ * @param {IDBTransaction} transaction The transaction that wraps this upgrade.
  */
-export function dbUpgrade (db, oldVersion) {
+export function dbUpgrade (db, oldVersion, transaction) {
+  // Note that values in this file are hard-coded, even though constants are
+  // available and preferred. The reason for this is if names change then old
+  // migrations and DB instances will not break as a result of such a change.
+
   switch (oldVersion) {
     case 0:
-      db.createObjectStore(DATABASE.COUNTDOWNS_STORE, {
-        keyPath: DATABASE.COUNTDOWN_ID
+      // Create the object store for the countdown timers
+      db.createObjectStore('countdown-timers', {
+        keyPath: 'id'
       })
     // Fallthrough
     case 1:
-      db.createObjectStore(DATABASE.LIST_ITEMS_STORE, {
-        keyPath: DATABASE.LIST_ITEM_ID,
+      // Rename the countdown timers object store. This is done due to a change
+      // in naming conventions.
+      transaction.objectStore('countdown-timers').name = 'countdownTimers'
+
+      // Create the object store for the list items
+      db.createObjectStore('listItems', {
+        keyPath: 'id',
         autoIncrement: true
-      }).createIndex(DATABASE.LIST_INDEX, DATABASE.LIST_ID)
+      }).createIndex('listIdIndex', 'listId')
   }
 }

--- a/app/db-upgrade.js
+++ b/app/db-upgrade.js
@@ -8,5 +8,13 @@ export function dbUpgrade (db, oldVersion) {
   switch (oldVersion) {
     case 0:
       db.createObjectStore('countdown-timers', { keyPath: 'id' })
+    // Fallthrough
+    case 1:
+      const editableListObjectStore = db.createObjectStore('editable-lists', {
+        keyPath: 'keyId',
+        autoIncrement: true
+      })
+
+      editableListObjectStore.createIndex('elementIdIndex', 'elementId')
   }
 }

--- a/app/main.js
+++ b/app/main.js
@@ -2,9 +2,9 @@ import { App } from './app.js'
 
 let app
 
-export function bootstrap (countdownElement) {
+export function bootstrap (countdownElement, distractionsElement) {
   if (!app) {
-    app = new App(countdownElement)
+    app = new App(countdownElement, distractionsElement)
   }
 
   return app

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 
     <section>
       <h2>Distractions</h2>
-      <editable-list></editable-list>
+      <editable-list id="distractions"></editable-list>
     </section>
   </main>
 </body>

--- a/lib/editable-list/editable-list.js
+++ b/lib/editable-list/editable-list.js
@@ -87,18 +87,20 @@ export class EditableList extends HTMLElement {
    * A "liadded" custom event will be dispatched on the li element once the
    * item has been added to the list.
    * @param {string} text The text to display in the list item.
-   * @param {null|number} [keyId=null] The keyID of the list element. This is
-   * should be set when the list items are retrieved from a data source.
+   * @param {null|number} [dbId=null] The database ID of the list element. This
+   * should be set when the list items are populated from a database.
    */
-  addListItem (text, keyId = null) {
+  addListItem (text, dbId = null) {
+    // noinspection JSValidateTypes
+    /** @type {RemovableListItem} */
     const liElement = document.createElement('li', {
       is: 'removable-li'
     })
 
     liElement.dataset.removeButtonText = this._removeItemText
     liElement.text = text
-    if (keyId != null) {
-      liElement.keyId = keyId
+    if (dbId != null) {
+      liElement.dbId = dbId
     }
 
     this._listElement.appendChild(liElement)

--- a/lib/editable-list/editable-list.js
+++ b/lib/editable-list/editable-list.js
@@ -94,8 +94,7 @@ export class EditableList extends HTMLElement {
     })
 
     liElement.dataset.removeButtonText = this._removeItemText
-
-    liElement.textContainer.textContent = text
+    liElement.text = text
 
     this._listElement.appendChild(liElement)
 
@@ -105,7 +104,7 @@ export class EditableList extends HTMLElement {
     const event = new CustomEvent('liadded', {
       bubbles: true,
       composed: true,
-      detail: { text }
+      detail: { liElement }
     })
     liElement.dispatchEvent(event)
   }

--- a/lib/editable-list/editable-list.js
+++ b/lib/editable-list/editable-list.js
@@ -87,14 +87,19 @@ export class EditableList extends HTMLElement {
    * A "liadded" custom event will be dispatched on the li element once the
    * item has been added to the list.
    * @param {string} text The text to display in the list item.
+   * @param {null|number} [keyId=null] The keyID of the list element. This is
+   * should be set when the list items are retrieved from a data source.
    */
-  addListItem (text) {
+  addListItem (text, keyId = null) {
     const liElement = document.createElement('li', {
       is: 'removable-li'
     })
 
     liElement.dataset.removeButtonText = this._removeItemText
     liElement.text = text
+    if (keyId != null) {
+      liElement.keyId = keyId
+    }
 
     this._listElement.appendChild(liElement)
 

--- a/lib/editable-list/removable-list-item.js
+++ b/lib/editable-list/removable-list-item.js
@@ -15,7 +15,7 @@ export class RemovableListItem extends HTMLLIElement {
   constructor () {
     super()
 
-    this._keyId = null
+    this._dbId = null
 
     // Create a `<span>` element which will act as a container for the text of
     // this list item
@@ -42,7 +42,7 @@ export class RemovableListItem extends HTMLLIElement {
       const event = new CustomEvent('liremoved', {
         bubbles: true,
         composed: true,
-        detail: { keyId: this.keyId }
+        detail: { dbId: this.dbId }
       })
       this.dispatchEvent(event)
 
@@ -60,19 +60,19 @@ export class RemovableListItem extends HTMLLIElement {
     this._textContainer.textContent = text
   }
 
-  get keyId () {
-    return this._keyId
+  get dbId () {
+    return this._dbId
   }
 
-  set keyId (id) {
+  set dbId (id) {
     if (!Number.isInteger(id)) {
       throw new TypeError('Key ID must be an integer')
     }
 
-    if (this._keyId == null) {
-      this._keyId = id
+    if (this._dbId == null) {
+      this._dbId = id
     } else {
-      throw new Error(`Key ID already set for list item #${this.keyId}`)
+      throw new Error(`Key ID already set for list item #${this.dbId}`)
     }
   }
 

--- a/lib/editable-list/removable-list-item.js
+++ b/lib/editable-list/removable-list-item.js
@@ -15,6 +15,8 @@ export class RemovableListItem extends HTMLLIElement {
   constructor () {
     super()
 
+    this._keyId = null
+
     // Create a `<span>` element which will act as a container for the text of
     // this list item
     this._textContainer = document.createElement('span')
@@ -39,7 +41,8 @@ export class RemovableListItem extends HTMLLIElement {
       // Dispatch an event that this list item has been removed
       const event = new CustomEvent('liremoved', {
         bubbles: true,
-        composed: true
+        composed: true,
+        detail: { keyId: this.keyId }
       })
       this.dispatchEvent(event)
 
@@ -49,13 +52,28 @@ export class RemovableListItem extends HTMLLIElement {
     })
   }
 
-  /**
-   * Accessor method to get the span element which contains the text of this
-   * list item. This is useful so that you can get and set the text contents.
-   * @returns {HTMLSpanElement}
-   */
-  get textContainer () {
-    return this._textContainer
+  get text () {
+    return this._textContainer.textContent
+  }
+
+  set text (text) {
+    this._textContainer.textContent = text
+  }
+
+  get keyId () {
+    return this._keyId
+  }
+
+  set keyId (id) {
+    if (!Number.isInteger(id)) {
+      throw new TypeError('Key ID must be an integer')
+    }
+
+    if (this._keyId == null) {
+      this._keyId = id
+    } else {
+      throw new Error(`Key ID already set for list item #${this.keyId}`)
+    }
   }
 
   /**
@@ -76,10 +94,8 @@ export class RemovableListItem extends HTMLLIElement {
    * @param {string} newValue The new value of the attribute after the change
    */
   async attributeChangedCallback (name, oldValue, newValue) {
-    switch (name) {
-      case 'data-remove-button-text':
-        this._removeButton.textContent = newValue
-        break
+    if (name === 'data-remove-button-text') {
+      this._removeButton.textContent = newValue
     }
   }
 }

--- a/main.js
+++ b/main.js
@@ -3,4 +3,5 @@ import './lib/editable-list/main.js'
 import { bootstrap } from './app/main.js'
 
 const countdownElement = document.getElementById('countdown')
-bootstrap(countdownElement)
+const distractionsElement = document.getElementById('distractions')
+bootstrap(countdownElement, distractionsElement)

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,16 +14,29 @@
       }
     },
     "@babel/generator": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
-      "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.2.2",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -47,12 +60,25 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -81,33 +107,69 @@
       "dev": true
     },
     "@babel/template": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/parser": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.3",
-        "@babel/types": "^7.2.2",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.5",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
+        "@babel/parser": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+          "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -118,9 +180,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -1125,9 +1187,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1208,9 +1270,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "loose-envify": {


### PR DESCRIPTION
# Overview
This PR adds saving of distractions. This means that any distractions added to the distractions list will be saved to the DB and will persist across sessions.

# Changes
- Added a new DB table to store the distractions. This table is intended as a general container for list items and is not only specific to the distractions list.
- Added the ability to add, delete, and retrieve distractions from the DB.
- Replaced hard-coded strings with constants. I created a dedicated `constants.js` file for this.