### PR TITLE
Added await to the `#displayTime` function

### DIFF
--- a/lib/countdown-timer/countdown-timer-element.js
+++ b/lib/countdown-timer/countdown-timer-element.js
@@ -135,7 +135,9 @@ export class CountdownTimerElement extends HTMLElement {
    * @param durationMs The number of milliseconds that are still left for this
    * countdown timer.
    */
-  #displayTime = (durationMs) => {
+  #displayTime = async (durationMs) => {
+    await this.#setupPromise
+
     const durationSeconds = durationMs / 1000
     let seconds = Math.floor(durationSeconds % 60)
 


### PR DESCRIPTION
# Overview
This closes #56. It was a simple race condition that caused the error.