### PR TITLE
Prevented a negative display of duration

### DIFF
--- a/src/CountdownTimer.js
+++ b/src/CountdownTimer.js
@@ -91,7 +91,7 @@ export function CountdownTimer({
       <Card.Body>
         <Card.Title>
           <div className={"display-1"}>
-            <Duration durationMs={timeLeftMs} />
+            <Duration durationMs={Math.max(timeLeftMs, 0)} />
           </div>
         </Card.Title>
         <ProgressBar now={(timeLeftMs / durationMs) * 100} />

--- a/src/Duration.js
+++ b/src/Duration.js
@@ -1,21 +1,34 @@
 import { Fragment } from "react";
 
 /**
+ * An object representing a formatted duration.
+ * @typedef {Object} DurationDisplay
+ * @property {boolean} isNegative Whether or not the duration is negative.
+ * @property {string} hours The hours left in this duration.
+ * @property {string} minutes The minutes left in this duration.
+ * @property {string} seconds The seconds left in this duration.
+ */
+
+/**
  * Converts the given duration into hours, minutes, and seconds strings.
  * @nosideeffects
  * @param {number} durationMs The duration in milliseconds.
- * @return {{hours: string, seconds: string, minutes: string}}
+ * @return {DurationDisplay}
  */
 function durationToDisplayStrings(durationMs) {
+  const isNegative = durationMs < 0;
+  durationMs = Math.abs(durationMs);
+
   const durationSeconds = durationMs / 1000;
   const seconds = `${Math.floor(durationSeconds % 60)}`.padStart(2, "0");
 
   const durationMinutes = durationSeconds / 60;
   const minutes = `${Math.floor(durationMinutes % 60)}`.padStart(2, "0");
 
-  const hours = `${Math.floor(minutes / 60)}`.padStart(2, "0");
+  const hours = `${Math.floor(durationMinutes / 60)}`.padStart(2, "0");
 
   return {
+    isNegative,
     hours,
     minutes,
     seconds,
@@ -29,11 +42,15 @@ function durationToDisplayStrings(durationMs) {
  * @return {JSX.Element}
  */
 export function Duration({ durationMs }) {
-  const { hours, minutes, seconds } = durationToDisplayStrings(durationMs);
+  const { isNegative, hours, minutes, seconds } =
+    durationToDisplayStrings(durationMs);
 
   return (
     <Fragment>
-      <span className={"text-nowrap"}>{hours}</span>
+      <span className={"text-nowrap"}>
+        {isNegative ? "-" : ""}
+        {hours}
+      </span>
       <span className={"text-nowrap"}>:{minutes}</span>
       <span className={"text-nowrap"}>:{seconds}</span>
     </Fragment>


### PR DESCRIPTION
# Overview
This PR prevents negative durations from being displayed to the user. Closes #76.

# Details
- Added support for negative durations to the `Duration` component for added functionality.
- Clamped the minimum time left to 0 in `CountdownTimer` to prevent a negative duration from displaying.